### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report / Bug 反馈
+description: Report a reproducible problem in the container image, docs, or workflow.
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        Please include enough detail for us to reproduce the issue inside `oh-my-openpod`.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary / 问题概述
+      description: What went wrong?
+      placeholder: A short description of the problem.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / 版本
+      description: Image tag, commit SHA, or branch name.
+      placeholder: "Example: ghcr.io/zhangdw156/oh-my-openpod:latest"
+    validations:
+      required: true
+  - type: dropdown
+    id: install_path
+    attributes:
+      label: How are you running it? / 使用方式
+      options:
+        - docker compose
+        - docker run
+        - local Docker build
+        - GHCR prebuilt image
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce / 复现步骤
+      description: List the exact steps or commands used.
+      placeholder: |
+        1. Run ...
+        2. Enter the container ...
+        3. Execute ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result / 期望结果
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result / 实际结果
+      placeholder: What happened instead? Include error output if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / 环境信息
+      description: Host OS, architecture, Docker version, shell, mounted project type, etc.
+      placeholder: |
+        Host OS:
+        CPU arch:
+        Docker version:
+        Project type:
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Context / 补充信息
+      placeholder: Logs, screenshots, links, or possible root cause.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation / 文档
+    url: https://github.com/zhangdw156/oh-my-openpod/blob/main/README.md
+    about: Check the README before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature Request / 功能建议
+description: Suggest an improvement to the image, workflow, or developer experience.
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion.
+
+        Clear motivation and a concrete proposal help us evaluate changes quickly.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to Solve / 需要解决的问题
+      description: What pain point or missing capability are you running into?
+      placeholder: Describe the use case and why the current setup is not enough.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution / 建议方案
+      description: What change would you like to see?
+      placeholder: Describe the proposed behavior, tools, or workflow.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered / 替代方案
+      description: Any tradeoffs or alternatives already considered?
+      placeholder: Existing workaround, competing approach, or reasons to avoid another option.
+    validations:
+      required: false
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and Impact / 影响范围
+      description: Which parts of the project would this affect?
+      placeholder: Docker image, shell setup, docs, compose workflow, CI, etc.
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Context / 补充信息
+      placeholder: Links, references, screenshots, or related issues.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- add GitHub issue templates for bug reports and feature requests
- disable blank issues and point reporters to the README
- make future tracking easier for work items such as #1

## Testing
- not run (GitHub metadata change only)
