### PR TITLE
release: cut 0.2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       network: host
-    image: oh-my-openpod:0.2.0-dev
+    image: oh-my-openpod:0.2.0
     container_name: oh-my-openpod
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary
- switch the compose image tag from `0.2.0-dev` to `0.2.0`
- let the `Publish Docker Image` workflow publish the release image from `main`

## Notes
- after this PR merges, GHCR should publish:
  - `ghcr.io/zhangdw156/oh-my-openpod:0.2.0`
  - `ghcr.io/zhangdw156/oh-my-openpod:latest`
