### PR TITLE
chore: bump version to 0.4.0-dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       network: host
-    image: oh-my-openpod:0.3.0
+    image: oh-my-openpod:0.4.0-dev
     container_name: oh-my-openpod
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary
- switch the compose image tag from `0.3.0` to `0.4.0-dev`
- move `main` back to the next development version after the 0.3.0 release

## Notes
- the publish workflow should skip pushing GHCR images for `-dev` tags
