### PR TITLE
feat: add vim and .dev0 versioning

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -45,7 +45,7 @@ jobs:
           image_name="ghcr.io/${owner}/${repo}"
 
           publish="true"
-          if [[ "$version" == *-dev ]]; then
+          if [[ "$version" == *-dev || "$version" =~ \.dev[0-9]+$ ]]; then
             publish="false"
           fi
 
@@ -106,7 +106,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${PUBLISH}" != "true" ]]; then
-            echo "Skipped publishing because docker-compose.yml uses dev tag \`${VERSION}\`." >> "$GITHUB_STEP_SUMMARY"
+            echo "Skipped publishing because docker-compose.yml uses a development version \`${VERSION}\`." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,13 +29,13 @@ oh-my-openpod/
 版本号唯一维护在 `docker-compose.yml` 的 `image` 字段中：
 
 ```yaml
-image: oh-my-openpod:x.y.z-dev   # 开发中
+image: oh-my-openpod:x.y.z.dev0  # 开发中
 image: oh-my-openpod:x.y.z       # 正式发布
 ```
 
 | 版本格式 | 含义 |
 |----------|------|
-| `x.y.z-dev` | 开发中，尚未发布 |
+| `x.y.z.devN` | 开发中，尚未发布 |
 | `x.y.z` | 已发布的正式版本 |
 
 ## Issue 约定
@@ -68,7 +68,7 @@ git checkout main
 git pull --ff-only origin main
 git checkout -b release/x.y.z
 
-# 2. 修改 docker-compose.yml 中 image 的 tag（去掉 -dev）
+# 2. 修改 docker-compose.yml 中 image 的 tag（去掉开发后缀）
 #    image: oh-my-openpod:x.y.z
 git add docker-compose.yml
 git commit -m "release: cut x.y.z"
@@ -87,11 +87,11 @@ git push origin vx.y.z
 
 # 5. 开始下一个版本的开发
 git checkout -b chore/bump-version-to-next-dev
-#    image: oh-my-openpod:<next-version>-dev
+#    image: oh-my-openpod:<next-version>.dev0
 git add docker-compose.yml
-git commit -m "chore: bump version to <next-version>-dev"
+git commit -m "chore: bump version to <next-version>.dev0"
 git push -u origin chore/bump-version-to-next-dev
 
 # 6. 提 PR 合并到 main
-#    这次 workflow 会自动跳过镜像发布，因为 tag 以 -dev 结尾
+#    这次 workflow 会自动跳过镜像发布，因为版本使用 .devN 开发后缀
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:24.04 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends \
     zsh \
     git \
+    vim \
     curl \
     fzf \
     bat \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       network: host
-    image: oh-my-openpod:0.4.0-dev
+    image: oh-my-openpod:0.4.0.dev0
     container_name: oh-my-openpod
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary
- add `vim` to the image so `vim` and `vi` are available inside the container
- migrate development version naming from `x.y.z-dev` to `x.y.z.dev0`
- update the publish workflow so `.devN` versions are skipped automatically

## Testing
- `docker build -t oh-my-openpod:0.4.0.dev0-test .`
- `docker run --rm oh-my-openpod:0.4.0.dev0-test -lc 'command -v vim && vim --version | head -n 1 && command -v vi'`

Closes #11
