### PR TITLE
release: cut 0.3.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       network: host
-    image: oh-my-openpod:0.4.0.dev0
+    image: oh-my-openpod:0.3.1
     container_name: oh-my-openpod
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary
- switch the compose image tag from `0.4.0.dev0` to `0.3.1`
- publish the vim-enabled image as the 0.3.1 patch release

## Notes
- after merge, GHCR should publish:
  - `ghcr.io/zhangdw156/oh-my-openpod:0.3.1`
  - `ghcr.io/zhangdw156/oh-my-openpod:latest`
