### PR TITLE
chore: bump version to 0.4.0.dev2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       network: host
-    image: oh-my-openpod:0.4.0.dev1
+    image: oh-my-openpod:0.4.0.dev2
     container_name: oh-my-openpod
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary
- switch the compose image tag from `0.4.0.dev1` to `0.4.0.dev2`
- continue the current development line after merging the btop change

## Notes
- the publish workflow should skip pushing GHCR images for `.devN` versions
