### PR TITLE
refactor: install btop from official releases

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,6 +15,7 @@ oh-my-openpod/
 ├── DEVELOPMENT.md              # 开发者文档（本文件）
 ├── build/
 │   ├── install-antidote.sh
+│   ├── install-btop.sh
 │   ├── install-yazi.sh
 │   └── install-zellij.sh
 ├── config/
@@ -55,11 +56,11 @@ image: oh-my-openpod:x.y.z       # 正式发布
 
 ## 依赖安装约定
 
-- `build/` 目录存放镜像构建期使用的安装脚本，例如 `install-antidote.sh`、`install-yazi.sh` 和 `install-zellij.sh`
+- `build/` 目录存放镜像构建期使用的安装脚本，例如 `install-antidote.sh`、`install-btop.sh`、`install-yazi.sh` 和 `install-zellij.sh`
 - `config/` 目录存放要复制进镜像的 shell 配置文件
 - `vendor/` 目录保留，但只留给未来确实不适合通过 build 安装脚本获取的 vendored 依赖
 - `install-antidote.sh` 和 `install-zellij.sh` 默认跟随各自上游的最新正式 release，也可以通过构建参数覆盖到特定版本
-- 本地 `docker build` 仍需要构建环境能访问 GitHub，因为 Antidote、Yazi、Zellij 和 Zsh 插件都在构建期下载
+- 本地 `docker build` 仍需要构建环境能访问 GitHub，因为 Antidote、btop、Yazi、Zellij 和 Zsh 插件都在构建期下载
 
 ## 发布流程
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04 AS base
 # ---------- 1. 安装基础依赖 ----------
 RUN apt-get update && apt-get install -y --no-install-recommends \
     7zip \
-    btop \
+    bzip2 \
     zsh \
     git \
     vim \
@@ -36,43 +36,48 @@ COPY --from=ghcr.io/anomalyco/opencode /usr/lib/libstdc++.so.6 /usr/lib/musl-com
 COPY --from=ghcr.io/anomalyco/opencode /usr/lib/libgcc_s.so.1 /usr/lib/musl-compat/libgcc_s.so.1
 RUN echo "/lib:/usr/local/lib:/usr/lib:/usr/lib/musl-compat" > /etc/ld-musl-x86_64.path
 
-# ---------- 3. 安装 Antidote（默认使用官方最新 release，可通过构建参数覆盖）----------
+# ---------- 3. 安装 btop（默认使用官方最新 release，可通过构建参数覆盖）----------
+ARG TARGETARCH
+ARG BTOP_VERSION=latest
+COPY build/install-btop.sh /tmp/install-btop.sh
+RUN bash /tmp/install-btop.sh && rm -f /tmp/install-btop.sh
+
+# ---------- 4. 安装 Antidote（默认使用官方最新 release，可通过构建参数覆盖）----------
 ARG ANTIDOTE_VERSION=latest
 COPY build/install-antidote.sh /tmp/install-antidote.sh
 RUN bash /tmp/install-antidote.sh && rm -f /tmp/install-antidote.sh
 
-# ---------- 4. 安装 zellij（默认使用官方最新 release，可通过构建参数覆盖）----------
-ARG TARGETARCH
+# ---------- 5. 安装 zellij（默认使用官方最新 release，可通过构建参数覆盖）----------
 ARG ZELLIJ_VERSION=latest
 COPY build/install-zellij.sh /tmp/install-zellij.sh
 RUN bash /tmp/install-zellij.sh && rm -f /tmp/install-zellij.sh
 
-# ---------- 5. 安装 Yazi（默认使用官方最新 release，可通过构建参数覆盖）----------
+# ---------- 6. 安装 Yazi（默认使用官方最新 release，可通过构建参数覆盖）----------
 ARG YAZI_VERSION=latest
 COPY build/install-yazi.sh /tmp/install-yazi.sh
 RUN bash /tmp/install-yazi.sh && rm -f /tmp/install-yazi.sh
 
-# ---------- 6. 安装 uv (Python 包管理器) ----------
+# ---------- 7. 安装 uv (Python 包管理器) ----------
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-# ---------- 7. 环境变量 ----------
+# ---------- 8. 环境变量 ----------
 ENV TERM=xterm-256color
 ENV SHELL=/bin/zsh
 ENV UV_LINK_MODE=copy
 ENV TZ=Asia/Shanghai
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
-# ---------- 8. 允许 git 操作挂载目录（容器 root 与宿主机 UID 不同）----------
+# ---------- 9. 允许 git 操作挂载目录（容器 root 与宿主机 UID 不同）----------
 RUN git config --global --add safe.directory '*'
 
-# ---------- 9. 复制配置文件 ----------
+# ---------- 10. 复制配置文件 ----------
 COPY config/.zshrc /root/.zshrc
 COPY config/.p10k.zsh /root/.p10k.zsh
 COPY config/.zsh_plugins.txt /root/.zsh_plugins.txt
 
-# ---------- 10. 预下载插件 (构建时执行，加速启动) ----------
+# ---------- 11. 预下载插件 (构建时执行，加速启动) ----------
 RUN zsh -c "source /opt/antidote/antidote.zsh && antidote load /root/.zsh_plugins.txt" || true
 
-# ---------- 11. 启动设置 ----------
+# ---------- 12. 启动设置 ----------
 WORKDIR /workspace
 ENTRYPOINT ["/bin/zsh"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ PROJECT_DIR=/path/to/your/project docker compose up -d --build
 
 本地构建仍需要构建环境能访问 GitHub：
 
-- 下载 Antidote、Yazi 和 Zellij
+- 下载 Antidote、btop、Yazi 和 Zellij
 - 预拉取 `.zsh_plugins.txt` 中列出的插件仓库
 
 ### 4. 方式 B：直接使用 GHCR 预构建镜像
@@ -163,6 +163,7 @@ oh-my-openpod/
 ├── docker-compose.yml      # 编排配置 & 版本号
 ├── build/
 │   ├── install-antidote.sh # 安装 Antidote
+│   ├── install-btop.sh     # 安装 btop
 │   ├── install-yazi.sh     # 安装 Yazi
 │   └── install-zellij.sh   # 安装 Zellij
 ├── .env.example            # 环境变量模板

--- a/README_EN.md
+++ b/README_EN.md
@@ -73,7 +73,7 @@ PROJECT_DIR=/path/to/your/project docker compose up -d --build
 
 Local image builds still need GitHub access during the build in order to:
 
-- download Antidote, Yazi, and Zellij
+- download Antidote, btop, Yazi, and Zellij
 - prefetch the plugin repositories listed in `.zsh_plugins.txt`
 
 ### 4. Option B: Use the Prebuilt GHCR Image
@@ -162,6 +162,7 @@ oh-my-openpod/
 ├── docker-compose.yml      # Orchestration & version
 ├── build/
 │   ├── install-antidote.sh # Install Antidote
+│   ├── install-btop.sh     # Install btop
 │   ├── install-yazi.sh     # Install Yazi
 │   └── install-zellij.sh   # Install Zellij
 ├── .env.example            # Environment variable template

--- a/build/install-btop.sh
+++ b/build/install-btop.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${BTOP_VERSION:-latest}"
+target_arch="${TARGETARCH:-}"
+curl_retry=(
+  curl
+  -fsSL
+  --retry 5
+  --retry-delay 2
+  --retry-connrefused
+  --connect-timeout 15
+)
+
+if [[ -z "${target_arch}" ]]; then
+  target_arch="$(dpkg --print-architecture)"
+fi
+
+case "${target_arch}" in
+  amd64|x86_64)
+    btop_arch="x86_64"
+    ;;
+  arm64|aarch64)
+    btop_arch="aarch64"
+    ;;
+  *)
+    echo "Unsupported architecture for btop: ${target_arch}" >&2
+    exit 1
+    ;;
+esac
+
+archive_name="btop-${btop_arch}-unknown-linux-musl.tbz"
+
+if [[ "${version}" == "latest" ]]; then
+  release_url="https://github.com/aristocratos/btop/releases/latest/download"
+else
+  release_url="https://github.com/aristocratos/btop/releases/download/${version}"
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+"${curl_retry[@]}" "${release_url}/${archive_name}" -o "${tmp_dir}/btop.tbz"
+tar -xjf "${tmp_dir}/btop.tbz" -C "${tmp_dir}"
+
+rm -rf /opt/btop
+mv "${tmp_dir}/btop" /opt/btop
+ln -sf /opt/btop/bin/btop /usr/local/bin/btop
+
+test -x /usr/local/bin/btop


### PR DESCRIPTION
## Summary
- replace the `apt`-based `btop` install with `build/install-btop.sh`
- download `btop` from official release assets using the same build-script pattern used for other standalone tools
- update docs to reflect the new installation path and build-time downloads

## Testing
- validated the `btop` release asset layout from the official release
- downloaded and executed the latest x86_64 release binary successfully via the install-script flow
- attempted a full Docker build, but the environment's apt path remained too slow for a reliable end-to-end run

Closes #21
