### PR TITLE
chore: bump version to 0.4.0.dev4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       network: host
-    image: oh-my-openpod:0.4.0.dev3
+    image: oh-my-openpod:0.4.0.dev4
     container_name: oh-my-openpod
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary
- bump the development image tag in `docker-compose.yml` from `0.4.0.dev3` to `0.4.0.dev4`
- keep `main` on the next development iteration after merging the vendored build asset work from #27
