### PR TITLE
docs: use openpod as runtime container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ docker pull ghcr.io/zhangdw156/oh-my-openpod:0.1.0
 
 # 直接启动并进入容器
 docker run --rm -it \
-  --name oh-my-openpod \
+  --name openpod \
   --network host \
   -v "${PROJECT_DIR:-$HOME/projects}:/workspace" \
   -v "$(pwd)/opencode.json:/root/.config/opencode/config.json:ro" \
@@ -103,6 +103,8 @@ docker run --rm -it \
 ```text
 ghcr.io/zhangdw156/oh-my-openpod
 ```
+
+默认运行容器名使用更短的 `openpod`；项目名和镜像名仍然保持为 `oh-my-openpod`。
 
 ### 5. 进入容器，开始工作
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -88,7 +88,7 @@ docker pull ghcr.io/zhangdw156/oh-my-openpod:0.1.0
 
 # Start and enter the container directly
 docker run --rm -it \
-  --name oh-my-openpod \
+  --name openpod \
   --network host \
   -v "${PROJECT_DIR:-$HOME/projects}:/workspace" \
   -v "$(pwd)/opencode.json:/root/.config/opencode/config.json:ro" \
@@ -103,6 +103,8 @@ Image URL:
 ```text
 ghcr.io/zhangdw156/oh-my-openpod
 ```
+
+The default runtime container name is the shorter `openpod`; the project name and image name remain `oh-my-openpod`.
 
 ### 5. Enter the Container
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       network: host
     image: oh-my-openpod:0.4.0.dev4
-    container_name: oh-my-openpod
+    container_name: openpod
     stdin_open: true
     tty: true
     working_dir: /workspace


### PR DESCRIPTION
## Summary
- change the default compose container name from `oh-my-openpod` to `openpod`
- update the `docker run --name` examples in both README files to use `openpod`
- clarify that the project name and image name remain `oh-my-openpod` while the runtime container name is `openpod`

Closes #29

## Verification
- `docker compose config >/dev/null`
- confirmed `docker-compose.yml`, `README.md`, and `README_EN.md` now use `openpod` consistently for the runtime container name
