### PR TITLE
feat: add bootstrap mode for non-Docker environments

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,73 @@
+name: Epic / 史诗任务
+description: Track a multi-step initiative that spans multiple workstreams or follow-up issues.
+title: "[Epic] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for outlining a larger initiative.
+
+        Please capture the motivation, intended scope, and validation criteria so follow-up work can stay aligned.
+  - type: textarea
+    id: background
+    attributes:
+      label: Background / 背景
+      description: What problem, opportunity, or context is driving this epic?
+      placeholder: Describe the current situation and why this initiative matters now.
+    validations:
+      required: true
+  - type: textarea
+    id: goals
+    attributes:
+      label: Goals / 目标
+      description: What outcomes should this epic achieve?
+      placeholder: List the desired outcomes or user capabilities this work should unlock.
+    validations:
+      required: true
+  - type: textarea
+    id: workstreams
+    attributes:
+      label: Proposed Workstreams / 拟议工作流
+      description: What major tracks of work do you expect?
+      placeholder: Break the initiative into implementation areas, milestones, or child issues.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals / 不在范围
+      description: What is explicitly out of scope for this epic?
+      placeholder: Clarify what should not be addressed as part of this initiative.
+    validations:
+      required: false
+  - type: textarea
+    id: risks
+    attributes:
+      label: Constraints and Risks / 约束与风险
+      description: What constraints, compatibility concerns, or risks should be planned for?
+      placeholder: Environment assumptions, dependency limitations, rollout concerns, etc.
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation and Success Criteria / 验证与成功标准
+      description: How will we know this epic is complete and successful?
+      placeholder: Tests, verification commands, user outcomes, and documentation expectations.
+    validations:
+      required: true
+  - type: textarea
+    id: follow_ups
+    attributes:
+      label: Rollout and Follow-ups / 推进与后续
+      description: Any sequencing, rollout notes, or known follow-up tasks?
+      placeholder: Related issues, rollout order, migration notes, or future enhancements.
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Context / 补充信息
+      placeholder: References, links, screenshots, or related discussions.
+    validations:
+      required: false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,6 +52,7 @@ image: oh-my-openpod:x.y.z       # 正式发布
 ## Issue 约定
 
 - 新 issue 默认通过 GitHub Web UI 的 issue form 创建，统一走 `.github/ISSUE_TEMPLATE/`
+- 史诗任务使用 `Epic / 史诗任务` 模板，标题前缀保持为 `[Epic] `
 - 功能建议使用 `Feature Request / 功能建议` 模板，标题前缀保持为 `[Feature] `
 - 缺陷反馈使用 `Bug Report / Bug 反馈` 模板，标题前缀保持为 `[Bug] `
 - `gh issue create` 不会自动套用 issue form；除非手动补齐相同标题和表单内容，否则不要直接用 CLI 裸建 issue
@@ -66,6 +67,7 @@ image: oh-my-openpod:x.y.z       # 正式发布
 ## 依赖安装约定
 
 - `build/` 目录存放镜像构建期使用的安装脚本，例如 `install-antidote.sh`、`install-btop.sh`、`install-yazi.sh` 和 `install-zellij.sh`
+- 这些安装脚本同时也是 bootstrap 模式的基础构件；新增脚本时优先保持可通过环境变量改写安装前缀与目标路径
 - `build/update-vendor-assets.sh` 用于刷新仓库内维护的 release 包、Zsh 插件快照和 OpenCode 插件包快照
 - `config/` 目录存放要复制进镜像的配置文件，包括 shell 配置和内置的 `opencode.json`
 - `vendor/releases/` 存放构建脚本使用的固定 release 包，`vendor/zsh/` 存放默认 shell 使用的插件源码快照

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cp .env.example .env        # 填入 API Key、自定义挂载路径等
 
 `.env` 支持官方 API 和自部署的 OpenAI / Anthropic 兼容接口，详见 [.env.example](.env.example)。
 
-### 3. 方式 A：本地构建并启动
+### 3. 方式 A：Docker 模式（默认推荐）
 
 若需使用 `.env`，请先完成 [第 2 步「配置（可选）」](#2-配置可选) 再执行下方命令。
 
@@ -83,7 +83,48 @@ PROJECT_DIR=/path/to/your/project docker compose up -d --build
 
 仍然需要联网的只有基础镜像来源，例如 Docker Hub 和 GHCR。
 
-### 4. 方式 B：直接使用 GHCR 预构建镜像
+### 4. 方式 B：Bootstrap 模式（无 Docker / 已有容器）
+
+当服务器上没有 Docker，或者你已经在一个现成的 Linux 容器里时，可以直接把当前环境 bootstrap 成 openpod 风格环境。
+
+当前 bootstrap 模式的初始支持范围：
+
+- Linux
+- Debian / Ubuntu 风格环境（要求 `dpkg` / `dpkg-deb` 可用）
+- 推荐优先使用用户态安装，不覆盖现有 `~/.zshrc`
+
+```bash
+# 默认用户态安装到 ~/.local/openpod
+bash install/bootstrap.sh --user
+
+# 让当前 shell 获取 openpod 环境变量
+source ~/.local/openpod/env.sh
+
+# 进入 openpod shell
+openpod-shell
+```
+
+也可以直接执行命令而不先进入交互 shell：
+
+```bash
+openpod-shell -lc 'opencode debug config'
+openpod-shell -lc 'opencode debug skill'
+```
+
+如需系统级安装，可在具备 root 权限时使用：
+
+```bash
+sudo bash install/bootstrap.sh --system
+```
+
+注意：
+
+- bootstrap 模式会复用仓库内 vendored 的 release 包、Zsh 插件快照和 OpenCode 插件包
+- `superpowers` 仍然保持完整包结构，不会被拆平
+- 当前不会自动修改你的 `~/.zshrc`；shell 配置会写到安装前缀下的 `shell/` 目录
+- `uv` 和 `opencode` 在目标 `bin` 目录不存在时会通过各自官方安装脚本补齐
+
+### 5. 方式 C：直接使用 GHCR 预构建镜像
 
 如果你不想在本地构建，也可以直接使用发布到 GitHub Container Registry 的镜像：
 
@@ -128,7 +169,7 @@ ghcr.io/zhangdw156/oh-my-openpod
 
 默认运行容器名使用更短的 `openpod`；项目名和镜像名仍然保持为 `oh-my-openpod`。
 
-### 5. 进入容器，开始工作
+### 6. 进入容器或 shell，开始工作
 
 如果你使用的是 `docker compose` 方式，可以这样进入容器：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -67,7 +67,7 @@ If you are using openpod to work on a project and want project-specific OpenCode
 
 `.env` supports both official APIs and self-hosted OpenAI / Anthropic compatible endpoints. See [.env.example](.env.example) for details.
 
-### 3. Option A: Build Locally and Start
+### 3. Option A: Docker Mode (Recommended)
 
 If you need `.env`, complete [step 2 “Configure (Optional)”](#2-configure-optional) before running the commands below.
 
@@ -83,7 +83,48 @@ Local image builds now use the vendored release assets, Zsh plugin snapshots, an
 
 The remaining network requirement is access to base image registries such as Docker Hub and GHCR.
 
-### 4. Option B: Use the Prebuilt GHCR Image
+### 4. Option B: Bootstrap Mode (No Docker / Existing Container)
+
+If the server does not have Docker, or you are already inside an existing Linux container, you can bootstrap the current environment into an openpod-style setup in place.
+
+Initial bootstrap support is intentionally narrow:
+
+- Linux
+- Debian/Ubuntu-style environments with `dpkg` and `dpkg-deb`
+- user-scoped installs are the preferred default and do not overwrite an existing `~/.zshrc`
+
+```bash
+# Default user-scoped install into ~/.local/openpod
+bash install/bootstrap.sh --user
+
+# Load openpod environment variables into the current shell
+source ~/.local/openpod/env.sh
+
+# Enter the openpod shell
+openpod-shell
+```
+
+You can also run commands directly without entering an interactive shell first:
+
+```bash
+openpod-shell -lc 'opencode debug config'
+openpod-shell -lc 'opencode debug skill'
+```
+
+If you explicitly want a system-wide install and have root access:
+
+```bash
+sudo bash install/bootstrap.sh --system
+```
+
+Notes:
+
+- bootstrap mode reuses the vendored release assets, Zsh plugin snapshots, and OpenCode plugin packages stored in this repository
+- `superpowers` keeps its full upstream package layout intact
+- bootstrap mode does not modify your `~/.zshrc`; shell config is written under the install prefix in `shell/`
+- `uv` and `opencode` are installed via their official install scripts only if they are missing from the target `bin` directory
+
+### 5. Option C: Use the Prebuilt GHCR Image
 
 If you do not want to build locally, you can use the image published to GitHub Container Registry directly:
 
@@ -128,7 +169,7 @@ ghcr.io/zhangdw156/oh-my-openpod
 
 The default runtime container name is the shorter `openpod`; the project name and image name remain `oh-my-openpod`.
 
-### 5. Enter the Container
+### 6. Enter the Container or Shell
 
 If you are using the `docker compose` workflow, enter the container with:
 

--- a/bin/openpod-shell
+++ b/bin/openpod-shell
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prefix="${OPENPOD_PREFIX:-${HOME}/.local/openpod}"
+
+if [[ -f "${prefix}/env.sh" ]]; then
+  # shellcheck disable=SC1090
+  source "${prefix}/env.sh"
+fi
+
+shell_dir="${OPENPOD_PREFIX:-${prefix}}/shell"
+
+if [[ $# -eq 0 ]]; then
+  exec env ZDOTDIR="${shell_dir}" zsh -i
+else
+  exec env ZDOTDIR="${shell_dir}" zsh "$@"
+fi

--- a/build/install-antidote.sh
+++ b/build/install-antidote.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 
 version="v2.0.10"
-asset_dir="/opt/vendor/releases/antidote/${version}"
+asset_root="${OPENPOD_ASSET_ROOT:-/opt/vendor/releases}"
+asset_dir="${asset_root}/antidote/${version}"
 archive_name="antidote-${version}.tar.gz"
 archive_path="${asset_dir}/${archive_name}"
 checksum_file="${asset_dir}/SHA256SUMS"
+antidote_dir="${OPENPOD_ANTIDOTE_DIR:-/opt/antidote}"
 
 expected_sha="$(awk -v name="${archive_name}" '$2 == name {print $1}' "${checksum_file}")"
 actual_sha="$(sha256sum "${archive_path}" | awk '{print $1}')"
@@ -17,8 +19,8 @@ if [[ -z "${expected_sha}" || "${actual_sha}" != "${expected_sha}" ]]; then
   exit 1
 fi
 
-rm -rf /opt/antidote
-mkdir -p /opt/antidote
-tar -xzf "${archive_path}" --strip-components=1 -C /opt/antidote
+rm -rf "${antidote_dir}"
+mkdir -p "${antidote_dir}"
+tar -xzf "${archive_path}" --strip-components=1 -C "${antidote_dir}"
 
-test -f /opt/antidote/antidote.zsh
+test -f "${antidote_dir}/antidote.zsh"

--- a/build/install-btop.sh
+++ b/build/install-btop.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 target_arch="${TARGETARCH:-}"
 version="v1.4.6"
-asset_dir="/opt/vendor/releases/btop/${version}"
+asset_root="${OPENPOD_ASSET_ROOT:-/opt/vendor/releases}"
+asset_dir="${asset_root}/btop/${version}"
+bin_dir="${OPENPOD_BIN_DIR:-/usr/local/bin}"
+btop_dir="${OPENPOD_BTOP_DIR:-/opt/btop}"
 
 if [[ -z "${target_arch}" ]]; then
   target_arch="$(dpkg --print-architecture)"
@@ -42,10 +45,12 @@ if [[ -z "${expected_sha}" || "${actual_sha}" != "${expected_sha}" ]]; then
   exit 1
 fi
 
+mkdir -p "${bin_dir}"
+rm -rf "${btop_dir}"
+mkdir -p "$(dirname "${btop_dir}")"
+
 tar -xjf "${archive_path}" -C "${tmp_dir}"
+mv "${tmp_dir}/btop" "${btop_dir}"
+ln -sf "${btop_dir}/bin/btop" "${bin_dir}/btop"
 
-rm -rf /opt/btop
-mv "${tmp_dir}/btop" /opt/btop
-ln -sf /opt/btop/bin/btop /usr/local/bin/btop
-
-test -x /usr/local/bin/btop
+test -x "${bin_dir}/btop"

--- a/build/install-yazi.sh
+++ b/build/install-yazi.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 target_arch="${TARGETARCH:-}"
 version="v26.1.22"
-asset_dir="/opt/vendor/releases/yazi/${version}"
+asset_root="${OPENPOD_ASSET_ROOT:-/opt/vendor/releases}"
+asset_dir="${asset_root}/yazi/${version}"
+bin_dir="${OPENPOD_BIN_DIR:-/usr/local/bin}"
 
 if [[ -z "${target_arch}" ]]; then
   target_arch="$(dpkg --print-architecture)"
@@ -42,9 +44,13 @@ if [[ -z "${expected_sha}" || "${actual_sha}" != "${expected_sha}" ]]; then
   exit 1
 fi
 
-# Extract the upstream package payload directly so we can keep Yazi's
-# core navigation binaries without pulling in every optional preview helper.
-dpkg-deb -x "${asset_path}" /
+mkdir -p "${bin_dir}"
 
-test -x /usr/bin/yazi
-test -x /usr/bin/ya
+# Extract the upstream package payload into a staging directory so bootstrap mode
+# can install Yazi without writing directly into /. Keep only the core binaries.
+dpkg-deb -x "${asset_path}" "${tmp_dir}/root"
+install -m 0755 "${tmp_dir}/root/usr/bin/yazi" "${bin_dir}/yazi"
+install -m 0755 "${tmp_dir}/root/usr/bin/ya" "${bin_dir}/ya"
+
+test -x "${bin_dir}/yazi"
+test -x "${bin_dir}/ya"

--- a/build/install-zellij.sh
+++ b/build/install-zellij.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 target_arch="${TARGETARCH:-}"
 version="v0.44.0"
-asset_dir="/opt/vendor/releases/zellij/${version}"
+asset_root="${OPENPOD_ASSET_ROOT:-/opt/vendor/releases}"
+asset_dir="${asset_root}/zellij/${version}"
+bin_dir="${OPENPOD_BIN_DIR:-/usr/local/bin}"
 
 if [[ -z "${target_arch}" ]]; then
   target_arch="$(dpkg --print-architecture)"
@@ -46,4 +48,5 @@ if [[ "${actual_sha}" != "${expected_sha}" ]]; then
   exit 1
 fi
 
-install -m 0755 "${tmp_dir}/zellij" /usr/local/bin/zellij
+mkdir -p "${bin_dir}"
+install -m 0755 "${tmp_dir}/zellij" "${bin_dir}/zellij"

--- a/install/bootstrap.sh
+++ b/install/bootstrap.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mode="user"
+prefix_default="${HOME}/.local/openpod"
+prefix="${OPENPOD_PREFIX:-${prefix_default}}"
+
+usage() {
+  cat <<'EOF'
+Usage: bash install/bootstrap.sh [--user] [--system] [--prefix PATH]
+
+Bootstrap an openpod-like environment on a Linux host or inside an existing container.
+
+Options:
+  --user           Install into a user-owned prefix (default)
+  --system         Install into /opt/openpod with binaries under /usr/local/bin
+  --prefix PATH    Override the installation prefix
+  -h, --help       Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user)
+      mode="user"
+      prefix="${OPENPOD_PREFIX:-${HOME}/.local/openpod}"
+      shift
+      ;;
+    --system)
+      mode="system"
+      prefix="${OPENPOD_PREFIX:-/opt/openpod}"
+      shift
+      ;;
+    --prefix)
+      prefix="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "bootstrap mode currently supports Linux only" >&2
+  exit 1
+fi
+
+if ! command -v dpkg >/dev/null 2>&1 || ! command -v dpkg-deb >/dev/null 2>&1; then
+  echo "bootstrap mode currently requires Debian/Ubuntu-style dpkg tools" >&2
+  exit 1
+fi
+
+for cmd in bash curl tar sha256sum install zsh; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [[ "$mode" == "system" && "$(id -u)" -ne 0 ]]; then
+  echo "--system requires root privileges" >&2
+  exit 1
+fi
+
+bin_dir="${OPENPOD_BIN_DIR:-}"
+config_home="${OPENPOD_CONFIG_HOME:-}"
+data_home="${OPENPOD_DATA_HOME:-}"
+state_home="${OPENPOD_STATE_HOME:-}"
+cache_home="${OPENPOD_CACHE_HOME:-}"
+
+if [[ -z "${bin_dir}" ]]; then
+  if [[ "$mode" == "system" ]]; then
+    bin_dir="/usr/local/bin"
+  else
+    bin_dir="${HOME}/.local/bin"
+  fi
+fi
+
+if [[ -z "${config_home}" ]]; then
+  if [[ "$mode" == "system" ]]; then
+    config_home="/root/.config/opencode"
+  else
+    config_home="${HOME}/.config/opencode"
+  fi
+fi
+
+if [[ -z "${data_home}" ]]; then
+  if [[ "$mode" == "system" ]]; then
+    data_home="/root/.local/share/openpod"
+  else
+    data_home="${HOME}/.local/share/openpod"
+  fi
+fi
+
+if [[ -z "${state_home}" ]]; then
+  if [[ "$mode" == "system" ]]; then
+    state_home="/root/.local/state/openpod"
+  else
+    state_home="${HOME}/.local/state/openpod"
+  fi
+fi
+
+if [[ -z "${cache_home}" ]]; then
+  if [[ "$mode" == "system" ]]; then
+    cache_home="/root/.cache/openpod"
+  else
+    cache_home="${HOME}/.cache/openpod"
+  fi
+fi
+
+vendor_home="${prefix}/vendor"
+plugin_dir="${config_home}/plugins"
+skills_link="${config_home}/skills"
+shell_dir="${prefix}/shell"
+asset_root="${repo_root}/vendor/releases"
+
+mkdir -p "${prefix}" "${bin_dir}" "${config_home}" "${plugin_dir}" "${data_home}" "${state_home}" "${cache_home}" "${shell_dir}"
+rm -rf "${vendor_home}"
+cp -R "${repo_root}/vendor" "${vendor_home}"
+
+cat > "${shell_dir}/.zshrc" <<EOF
+# openpod bootstrap-managed zsh config
+export OPENPOD_PREFIX="${prefix}"
+export OPENPOD_BIN_DIR="${bin_dir}"
+export OPENPOD_CONFIG_DIR="${config_home}"
+export OPENPOD_DATA_HOME="${data_home}"
+export OPENPOD_STATE_HOME="${state_home}"
+export OPENPOD_CACHE_HOME="${cache_home}"
+export PATH="${bin_dir}:\$PATH"
+export ZSH="${vendor_home}/zsh/ohmyzsh"
+export ZSH_DISABLE_COMPFIX=true
+export DISABLE_AUTO_UPDATE=true
+export LANG="\${LANG:-C.UTF-8}"
+export LC_ALL="\${LC_ALL:-C.UTF-8}"
+export TERM="\${TERM:-xterm-256color}"
+export UV_LINK_MODE=copy
+ZSH_THEME=""
+plugins=(git extract)
+source "\${ZSH}/oh-my-zsh.sh"
+source "${vendor_home}/zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
+source "${vendor_home}/zsh/zsh-history-substring-search/zsh-history-substring-search.zsh"
+source "${vendor_home}/zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+source "${vendor_home}/zsh/powerlevel10k/powerlevel10k.zsh-theme"
+[[ ! -f "${shell_dir}/.p10k.zsh" ]] || source "${shell_dir}/.p10k.zsh"
+alias cc=clear
+alias zj=zellij
+function y() {
+  local tmp="\$(mktemp -t yazi-cwd.XXXXXX)" cwd
+  command yazi "\$@" --cwd-file="\$tmp"
+  cwd="\$(command cat -- "\$tmp" 2>/dev/null)"
+  [ "\$cwd" != "\$PWD" ] && [ -d "\$cwd" ] && builtin cd -- "\$cwd"
+  rm -f -- "\$tmp"
+}
+EOF
+
+cat > "${prefix}/env.sh" <<EOF
+export OPENPOD_PREFIX="${prefix}"
+export OPENPOD_BIN_DIR="${bin_dir}"
+export OPENPOD_CONFIG_DIR="${config_home}"
+export OPENPOD_DATA_HOME="${data_home}"
+export OPENPOD_STATE_HOME="${state_home}"
+export OPENPOD_CACHE_HOME="${cache_home}"
+export PATH="${bin_dir}:\$PATH"
+export XDG_CONFIG_HOME="\${XDG_CONFIG_HOME:-${HOME}/.config}"
+export XDG_DATA_HOME="\${XDG_DATA_HOME:-${HOME}/.local/share}"
+export XDG_STATE_HOME="\${XDG_STATE_HOME:-${HOME}/.local/state}"
+export XDG_CACHE_HOME="\${XDG_CACHE_HOME:-${HOME}/.cache}"
+export UV_LINK_MODE=copy
+EOF
+
+cp "${repo_root}/config/.p10k.zsh" "${shell_dir}/.p10k.zsh"
+cp "${repo_root}/config/opencode.json" "${config_home}/config.json"
+ln -sfn "${vendor_home}/opencode/packages/superpowers/.opencode/plugins/superpowers.js" "${plugin_dir}/superpowers.js"
+ln -sfn "${vendor_home}/opencode/skills" "${skills_link}"
+
+export OPENPOD_ASSET_ROOT="${asset_root}"
+export OPENPOD_BIN_DIR="${bin_dir}"
+export OPENPOD_BTOP_DIR="${prefix}/opt/btop"
+export OPENPOD_ANTIDOTE_DIR="${prefix}/opt/antidote"
+
+bash "${repo_root}/build/install-btop.sh"
+bash "${repo_root}/build/install-antidote.sh"
+bash "${repo_root}/build/install-zellij.sh"
+bash "${repo_root}/build/install-yazi.sh"
+
+if [[ ! -x "${bin_dir}/uv" ]]; then
+  curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="${bin_dir}" UV_NO_MODIFY_PATH=1 sh
+fi
+
+need_opencode_install=0
+if [[ ! -x "${bin_dir}/opencode" ]]; then
+  need_opencode_install=1
+elif ! "${bin_dir}/opencode" --version >/dev/null 2>&1; then
+  need_opencode_install=1
+fi
+
+if [[ "${need_opencode_install}" == "1" ]]; then
+  opencode_home="$(mktemp -d)"
+  env HOME="${opencode_home}" PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" bash -c 'curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path'
+  install -m 0755 "${opencode_home}/.opencode/bin/opencode" "${bin_dir}/opencode"
+  rm -rf "${opencode_home}"
+fi
+
+cat > "${bin_dir}/openpod-shell" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+source "${prefix}/env.sh"
+if [[ \$# -eq 0 ]]; then
+  exec env ZDOTDIR="${shell_dir}" zsh -i
+else
+  exec env ZDOTDIR="${shell_dir}" zsh "\$@"
+fi
+EOF
+chmod 0755 "${bin_dir}/openpod-shell"
+
+cat <<EOF
+Bootstrap complete.
+
+Prefix: ${prefix}
+Bin dir: ${bin_dir}
+OpenCode config: ${config_home}
+
+Next steps:
+  source "${prefix}/env.sh"
+  openpod-shell
+
+Notes:
+- Existing ~/.zshrc was not modified.
+- Shell config lives under ${shell_dir}.
+EOF


### PR DESCRIPTION
## Summary
- add a Linux bootstrap mode for servers or existing containers that cannot use Docker
- make vendored installer scripts prefix-aware so bootstrap mode can reuse the same assets as the image build
- document the bootstrap workflow and add an Epic issue form for tracking larger initiatives

## Test plan
- [x] `bash install/bootstrap.sh --user --prefix /tmp/openpod-bootstrap-test`
- [x] `OPENPOD_PREFIX=/tmp/openpod-bootstrap-test /home/zhang/.local/bin/openpod-shell -lc 'command -v opencode && opencode --version'`
- [x] `OPENPOD_PREFIX=/tmp/openpod-bootstrap-test /home/zhang/.local/bin/openpod-shell -lc 'opencode debug paths'`
- [x] `OPENPOD_PREFIX=/tmp/openpod-bootstrap-test /home/zhang/.local/bin/openpod-shell -lc 'opencode debug skill'`
- [x] `docker build` regression check

## Related
- closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)