### PR TITLE
fix: pre-install LazyVim plugins during Docker build

### DIFF
--- a/Dockerfile.devpod
+++ b/Dockerfile.devpod
@@ -36,6 +36,7 @@ RUN bash /tmp/install-python-dev-tools.sh && rm -f /tmp/install-python-dev-tools
 COPY config/nvim /opt/devpod-config/nvim
 COPY build/install-lazyvim.sh /tmp/install-lazyvim.sh
 RUN OPENPOD_NVM_OVERLAY_DIR=/opt/devpod-config/nvim bash /tmp/install-lazyvim.sh && rm -f /tmp/install-lazyvim.sh
+RUN nvim --headless "+Lazy! sync" +qa
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8

--- a/vendor/nvim/lazyvim-starter/lua/config/lazy.lua
+++ b/vendor/nvim/lazyvim-starter/lua/config/lazy.lua
@@ -32,9 +32,9 @@ require("lazy").setup({
   },
   install = { colorscheme = { "tokyonight", "habamax" } },
   checker = {
-    enabled = true, -- check for plugin updates periodically
-    notify = false, -- notify on update
-  }, -- automatically check for plugin updates
+    enabled = false, -- disabled: plugins are pre-installed and managed by the image build
+    notify = false,
+  },
   performance = {
     rtp = {
       -- disable some rtp plugins


### PR DESCRIPTION
## Summary
- Add `nvim --headless "+Lazy! sync" +qa` step in `Dockerfile.devpod` so all LazyVim plugins are pre-installed during image build
- Disable lazy.nvim update checker (useless in container environment)

Closes #51

## Test plan
- [ ] Build devpod image: `docker compose -f docker/openpod/docker-compose.yaml build devpod`
- [ ] Verify plugins exist: `docker run --rm devpod:local -lc 'ls ~/.local/share/nvim/lazy/'`
- [ ] Run nvim in offline mode and confirm it starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)