### PR TITLE
fix: use architecture-aware musl path in openpod Dockerfile

### DIFF
--- a/docker/openpod/Dockerfile
+++ b/docker/openpod/Dockerfile
@@ -1,10 +1,12 @@
 ARG DEVPOD_BASE_IMAGE=devpod
 FROM ${DEVPOD_BASE_IMAGE}
 
+ARG TARGETARCH
 COPY --from=ghcr.io/anomalyco/opencode /usr/local/bin/opencode /usr/local/bin/opencode
 COPY --from=ghcr.io/anomalyco/opencode /usr/lib/libstdc++.so.6 /usr/lib/musl-compat/libstdc++.so.6
 COPY --from=ghcr.io/anomalyco/opencode /usr/lib/libgcc_s.so.1 /usr/lib/musl-compat/libgcc_s.so.1
-RUN echo "/lib:/usr/local/lib:/usr/lib:/usr/lib/musl-compat" > /etc/ld-musl-x86_64.path
+RUN musl_arch="$(case "${TARGETARCH:-$(dpkg --print-architecture)}" in amd64|x86_64) echo x86_64;; arm64|aarch64) echo aarch64;; *) echo x86_64;; esac)" \
+    && echo "/lib:/usr/local/lib:/usr/lib:/usr/lib/musl-compat" > "/etc/ld-musl-${musl_arch}.path"
 
 COPY runtime/openpod/vendor/opencode /opt/vendor/opencode
 COPY runtime/openpod/config/opencode.json /root/.config/opencode/config.json


### PR DESCRIPTION
## Summary
- Derive musl dynamic linker path file name from `TARGETARCH` instead of hardcoding `ld-musl-x86_64.path`
- Fixes opencode startup failure on ARM64 where the expected file is `ld-musl-aarch64.path`

Closes #53

## Test plan
- [ ] Build on x86_64: verify `ld-musl-x86_64.path` is created
- [ ] Build on ARM64: verify `ld-musl-aarch64.path` is created
- [ ] Run `opencode --version` in both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)