### PR TITLE
fix: pin uv version to 0.11.3 for reproducible builds

### DIFF
--- a/Dockerfile.devpod
+++ b/Dockerfile.devpod
@@ -30,7 +30,7 @@ COPY build/install-yazi.sh /tmp/install-yazi.sh
 RUN bash /tmp/install-yazi.sh && rm -f /tmp/install-yazi.sh
 COPY build/install-neovim.sh /tmp/install-neovim.sh
 RUN bash /tmp/install-neovim.sh && rm -f /tmp/install-neovim.sh
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /uvx /usr/local/bin/
 COPY build/install-python-dev-tools.sh /tmp/install-python-dev-tools.sh
 RUN bash /tmp/install-python-dev-tools.sh && rm -f /tmp/install-python-dev-tools.sh
 COPY config/nvim /opt/devpod-config/nvim


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/astral-sh/uv` from `latest` to `0.11.3` in `Dockerfile.devpod`
- Ensures pyright and ruff installation is consistent across builds

Closes #55

## Test plan
- [ ] Build devpod image and verify `uv --version` outputs `0.11.3`
- [ ] Verify pyright and ruff install correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)