### PR TITLE
feat: split vendor COPY into separate layers for better Docker cache

### DIFF
--- a/Dockerfile.devpod
+++ b/Dockerfile.devpod
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     musl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY vendor /opt/vendor
+COPY vendor/releases /opt/vendor/releases
 
 ARG TARGETARCH
 COPY build/install-btop.sh /tmp/install-btop.sh
@@ -33,10 +33,14 @@ RUN bash /tmp/install-neovim.sh && rm -f /tmp/install-neovim.sh
 COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /uvx /usr/local/bin/
 COPY build/install-python-dev-tools.sh /tmp/install-python-dev-tools.sh
 RUN bash /tmp/install-python-dev-tools.sh && rm -f /tmp/install-python-dev-tools.sh
+
+COPY vendor/nvim /opt/vendor/nvim
 COPY config/nvim /opt/devpod-config/nvim
 COPY build/install-lazyvim.sh /tmp/install-lazyvim.sh
 RUN OPENPOD_NVM_OVERLAY_DIR=/opt/devpod-config/nvim bash /tmp/install-lazyvim.sh && rm -f /tmp/install-lazyvim.sh
 RUN nvim --headless "+Lazy! sync" +qa
+
+COPY vendor/zsh /opt/vendor/zsh
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
## Summary
- Split `COPY vendor /opt/vendor` into `vendor/releases`, `vendor/nvim`, `vendor/zsh`
- Each COPY is placed right before its consumer scripts
- Changing zsh plugins no longer invalidates binary install cache and vice versa

Closes #57

## Test plan
- [ ] Build devpod image successfully
- [ ] Verify all tools installed: btop, antidote, zellij, yazi, nvim
- [ ] Verify zsh plugins available at `/opt/vendor/zsh/`
- [ ] Modify only `vendor/zsh/` and rebuild — binary install layers should use cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)