### PR TITLE
feat(harness): add in-container upgrade commands and bootstrap latest

### DIFF
--- a/build/install-claude-code.sh
+++ b/build/install-claude-code.sh
@@ -3,8 +3,17 @@ set -euo pipefail
 
 claude_install_home="${OHMYDEVPOD_CLAUDE_INSTALL_HOME:?missing OHMYDEVPOD_CLAUDE_INSTALL_HOME}"
 bin_dir="${OHMYDEVPOD_BIN_DIR:?missing OHMYDEVPOD_BIN_DIR}"
-version="${OHMYDEVPOD_CLAUDE_CODE_VERSION:-2.1.92}"
+version="${OHMYDEVPOD_CLAUDE_CODE_VERSION:-}"
 bucket_url="${OHMYDEVPOD_CLAUDE_CODE_BUCKET_URL:-https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases}"
+
+if [[ -z "${version}" || "${version}" == "latest" ]]; then
+  version="$(curl -fsSL https://registry.npmjs.org/@anthropic-ai/claude-code/latest | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')"
+  if [[ -z "${version}" ]]; then
+    echo "failed to resolve latest Claude Code version from npm registry" >&2
+    exit 1
+  fi
+  echo "Resolved latest Claude Code version: ${version}"
+fi
 manifest_url="${bucket_url}/${version}/manifest.json"
 native_versions_dir="${claude_install_home}/.local/share/claude/versions"
 real_bin="${native_versions_dir}/${version}"

--- a/docker/claudepod/Dockerfile
+++ b/docker/claudepod/Dockerfile
@@ -2,7 +2,7 @@ ARG DEVPOD_BASE_IMAGE=devpod
 FROM ${DEVPOD_BASE_IMAGE}
 
 COPY build/install-claude-code.sh /opt/build/install-claude-code.sh
-RUN OHMYDEVPOD_BIN_DIR=/usr/local/bin OHMYDEVPOD_CLAUDE_INSTALL_HOME=/root bash /opt/build/install-claude-code.sh
+RUN OHMYDEVPOD_BIN_DIR=/usr/local/bin OHMYDEVPOD_CLAUDE_INSTALL_HOME=/root OHMYDEVPOD_CLAUDE_CODE_VERSION=2.1.92 bash /opt/build/install-claude-code.sh
 
 COPY runtime/claudepod /opt/runtime/claudepod
 RUN mkdir -p /root/.claude \

--- a/docker/claudepod/Dockerfile
+++ b/docker/claudepod/Dockerfile
@@ -1,16 +1,16 @@
 ARG DEVPOD_BASE_IMAGE=devpod
 FROM ${DEVPOD_BASE_IMAGE}
 
-COPY build/install-claude-code.sh /tmp/install-claude-code.sh
-RUN OHMYDEVPOD_BIN_DIR=/usr/local/bin OHMYDEVPOD_CLAUDE_INSTALL_HOME=/root bash /tmp/install-claude-code.sh \
-    && rm -f /tmp/install-claude-code.sh
+COPY build/install-claude-code.sh /opt/build/install-claude-code.sh
+RUN OHMYDEVPOD_BIN_DIR=/usr/local/bin OHMYDEVPOD_CLAUDE_INSTALL_HOME=/root bash /opt/build/install-claude-code.sh
 
 COPY runtime/claudepod /opt/runtime/claudepod
 RUN mkdir -p /root/.claude \
     && ln -sfn /opt/runtime/claudepod/skills /root/.claude/skills \
     && cp /opt/runtime/claudepod/bin/claude /usr/local/bin/claude \
     && cp /opt/runtime/claudepod/bin/claudepod-shell /usr/local/bin/claudepod-shell \
-    && chmod 0755 /usr/local/bin/claude /usr/local/bin/claudepod-shell
+    && cp /opt/runtime/claudepod/bin/claudepod-upgrade /usr/local/bin/claudepod-upgrade \
+    && chmod 0755 /usr/local/bin/claude /usr/local/bin/claudepod-shell /usr/local/bin/claudepod-upgrade
 
 # Sync flavor config into devpod-skel for --user support
 RUN cp -a /root/.claude /opt/devpod-skel/.claude \
@@ -22,4 +22,5 @@ RUN cp -a /root/.claude /opt/devpod-skel/.claude \
 ENV DISABLE_AUTOUPDATER=1
 ENV OHMYDEVPOD_CLAUDE_CODE_VERSION=2.1.92
 ENV OHMYDEVPOD_CLAUDE_REAL_BIN=/usr/local/bin/claude-real
+ENV OHMYDEVPOD_REPO_ROOT=/opt
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin

--- a/docker/codexpod/Dockerfile
+++ b/docker/codexpod/Dockerfile
@@ -3,6 +3,7 @@ FROM ${DEVPOD_BASE_IMAGE}
 
 COPY runtime/codexpod /opt/runtime/codexpod
 RUN OHMYDEVPOD_REPO_ROOT=/opt OHMYDEVPOD_PREFIX=/opt/codexpod OHMYDEVPOD_BIN_DIR=/usr/local/bin OHMYDEVPOD_CONFIG_HOME=/root/.codex \
+      OHMYDEVPOD_CODEX_VERSION=0.118.0 \
       bash /opt/runtime/codexpod/install-harness.sh
 
 # Sync flavor config into devpod-skel for --user support

--- a/docker/copilotpod/Dockerfile
+++ b/docker/copilotpod/Dockerfile
@@ -3,6 +3,7 @@ FROM ${DEVPOD_BASE_IMAGE}
 
 COPY runtime/copilotpod /opt/runtime/copilotpod
 RUN OHMYDEVPOD_REPO_ROOT=/opt OHMYDEVPOD_PREFIX=/opt/copilotpod OHMYDEVPOD_BIN_DIR=/usr/local/bin OHMYDEVPOD_CONFIG_HOME=/root/.copilot \
+      OHMYDEVPOD_COPILOT_VERSION=1.0.24 \
       bash /opt/runtime/copilotpod/install-harness.sh
 
 # Sync flavor config into devpod-skel for --user support

--- a/docker/geminipod/Dockerfile
+++ b/docker/geminipod/Dockerfile
@@ -3,6 +3,7 @@ FROM ${DEVPOD_BASE_IMAGE}
 
 COPY runtime/geminipod /opt/runtime/geminipod
 RUN OHMYDEVPOD_REPO_ROOT=/opt OHMYDEVPOD_PREFIX=/opt/geminipod OHMYDEVPOD_BIN_DIR=/usr/local/bin OHMYDEVPOD_CONFIG_HOME=/root/.gemini \
+      OHMYDEVPOD_GEMINI_VERSION=0.37.1 \
       bash /opt/runtime/geminipod/install-harness.sh
 
 # Sync flavor config into devpod-skel for --user support

--- a/docker/openpod/Dockerfile
+++ b/docker/openpod/Dockerfile
@@ -11,6 +11,7 @@ RUN musl_arch="$(case "${TARGETARCH:-$(dpkg --print-architecture)}" in amd64|x86
 COPY runtime/openpod/vendor/opencode /opt/vendor/opencode
 COPY runtime/openpod/config/opencode.json /root/.config/opencode/config.json
 COPY runtime/openpod/bin/openpod-shell /usr/local/bin/openpod-shell
+COPY runtime/openpod/bin/openpod-upgrade /usr/local/bin/openpod-upgrade
 RUN mkdir -p /root/.config/opencode/plugins \
     && ln -sf /opt/vendor/opencode/packages/superpowers/.opencode/plugins/superpowers.js /root/.config/opencode/plugins/superpowers.js \
     && ln -sfn /opt/vendor/opencode/skills /root/.config/opencode/skills \

--- a/runtime/claudepod/bin/claudepod-upgrade
+++ b/runtime/claudepod/bin/claudepod-upgrade
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+bin_dir="${OHMYDEVPOD_BIN_DIR:-/usr/local/bin}"
+repo_root="${OHMYDEVPOD_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+
+old_version="$(claude-real --version 2>/dev/null || echo 'unknown')"
+
+export OHMYDEVPOD_CLAUDE_CODE_VERSION="${version}"
+export OHMYDEVPOD_CLAUDE_INSTALL_HOME="${HOME}"
+export OHMYDEVPOD_BIN_DIR="${bin_dir}"
+
+install_script="${repo_root}/build/install-claude-code.sh"
+if [[ ! -f "${install_script}" ]]; then
+  install_script="/opt/build/install-claude-code.sh"
+fi
+
+bash "${install_script}"
+
+new_version="$(claude-real --version 2>/dev/null || echo 'unknown')"
+echo "Upgraded claude: ${old_version} -> ${new_version}"

--- a/runtime/claudepod/install-harness.sh
+++ b/runtime/claudepod/install-harness.sh
@@ -8,7 +8,7 @@ config_home="${OHMYDEVPOD_CONFIG_HOME:?missing OHMYDEVPOD_CONFIG_HOME}"
 mkdir -p "${config_home}"
 export OHMYDEVPOD_BIN_DIR="${bin_dir}"
 export OHMYDEVPOD_CLAUDE_INSTALL_HOME="${HOME}"
-export OHMYDEVPOD_CLAUDE_CODE_VERSION="${OHMYDEVPOD_CLAUDE_CODE_VERSION:-2.1.92}"
+export OHMYDEVPOD_CLAUDE_CODE_VERSION="${OHMYDEVPOD_CLAUDE_CODE_VERSION:-}"
 
 bash "${repo_root}/build/install-claude-code.sh"
 
@@ -18,3 +18,4 @@ fi
 
 install -m 0755 "${repo_root}/runtime/claudepod/bin/claude" "${bin_dir}/claude"
 install -m 0755 "${repo_root}/runtime/claudepod/bin/claudepod-shell" "${bin_dir}/claudepod-shell"
+install -m 0755 "${repo_root}/runtime/claudepod/bin/claudepod-upgrade" "${bin_dir}/claudepod-upgrade"

--- a/runtime/codexpod/bin/codexpod-upgrade
+++ b/runtime/codexpod/bin/codexpod-upgrade
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+prefix="${OHMYDEVPOD_PREFIX:-${HOME}/.local/codexpod}"
+bin_dir="${OHMYDEVPOD_BIN_DIR:-/usr/local/bin}"
+cli_prefix="${prefix}/opt/codex-cli"
+
+old_version="$(codex-real --version 2>/dev/null || echo 'unknown')"
+
+pkg="@openai/codex"
+[[ -n "${version}" ]] && pkg="${pkg}@${version}"
+
+npm install -g --prefix "${cli_prefix}" "${pkg}"
+ln -sfn "${cli_prefix}/bin/codex" "${bin_dir}/codex-real"
+
+new_version="$(codex-real --version 2>/dev/null || echo 'unknown')"
+echo "Upgraded codex: ${old_version} -> ${new_version}"

--- a/runtime/codexpod/install-harness.sh
+++ b/runtime/codexpod/install-harness.sh
@@ -6,7 +6,7 @@ prefix="${OHMYDEVPOD_PREFIX:?missing OHMYDEVPOD_PREFIX}"
 bin_dir="${OHMYDEVPOD_BIN_DIR:?missing OHMYDEVPOD_BIN_DIR}"
 config_home="${OHMYDEVPOD_CONFIG_HOME:?missing OHMYDEVPOD_CONFIG_HOME}"
 codex_prefix="${prefix}/opt/codex-cli"
-codex_version="${OHMYDEVPOD_CODEX_VERSION:-0.118.0}"
+codex_version="${OHMYDEVPOD_CODEX_VERSION:-}"
 skills_root="${repo_root}/runtime/codexpod/skills"
 
 if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
@@ -15,9 +15,12 @@ if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
 fi
 
 mkdir -p "${codex_prefix}" "${config_home}"
-npm install -g --prefix "${codex_prefix}" "@openai/codex@${codex_version}"
+codex_pkg="@openai/codex"
+[[ -n "${codex_version}" ]] && codex_pkg="${codex_pkg}@${codex_version}"
+npm install -g --prefix "${codex_prefix}" "${codex_pkg}"
 ln -sfn "${codex_prefix}/bin/codex" "${bin_dir}/codex-real"
 ln -sfn "${skills_root}" "${config_home}/skills"
 
 install -m 0755 "${repo_root}/runtime/codexpod/bin/codex" "${bin_dir}/codex"
 install -m 0755 "${repo_root}/runtime/codexpod/bin/codexpod-shell" "${bin_dir}/codexpod-shell"
+install -m 0755 "${repo_root}/runtime/codexpod/bin/codexpod-upgrade" "${bin_dir}/codexpod-upgrade"

--- a/runtime/copilotpod/bin/copilotpod-upgrade
+++ b/runtime/copilotpod/bin/copilotpod-upgrade
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+prefix="${OHMYDEVPOD_PREFIX:-${HOME}/.local/copilotpod}"
+bin_dir="${OHMYDEVPOD_BIN_DIR:-/usr/local/bin}"
+cli_prefix="${prefix}/opt/copilot-cli"
+
+old_version="$(copilot-real --version 2>/dev/null || echo 'unknown')"
+
+pkg="@github/copilot"
+[[ -n "${version}" ]] && pkg="${pkg}@${version}"
+
+npm install -g --prefix "${cli_prefix}" "${pkg}"
+ln -sfn "${cli_prefix}/bin/copilot" "${bin_dir}/copilot-real"
+
+new_version="$(copilot-real --version 2>/dev/null || echo 'unknown')"
+echo "Upgraded copilot: ${old_version} -> ${new_version}"

--- a/runtime/copilotpod/install-harness.sh
+++ b/runtime/copilotpod/install-harness.sh
@@ -6,7 +6,7 @@ prefix="${OHMYDEVPOD_PREFIX:?missing OHMYDEVPOD_PREFIX}"
 bin_dir="${OHMYDEVPOD_BIN_DIR:?missing OHMYDEVPOD_BIN_DIR}"
 config_home="${OHMYDEVPOD_CONFIG_HOME:?missing OHMYDEVPOD_CONFIG_HOME}"
 copilot_prefix="${prefix}/opt/copilot-cli"
-copilot_version="${OHMYDEVPOD_COPILOT_VERSION:-1.0.24}"
+copilot_version="${OHMYDEVPOD_COPILOT_VERSION:-}"
 skills_root="${repo_root}/runtime/copilotpod/skills"
 
 if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
@@ -15,9 +15,12 @@ if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
 fi
 
 mkdir -p "${copilot_prefix}" "${config_home}"
-npm install -g --prefix "${copilot_prefix}" "@github/copilot@${copilot_version}"
+copilot_pkg="@github/copilot"
+[[ -n "${copilot_version}" ]] && copilot_pkg="${copilot_pkg}@${copilot_version}"
+npm install -g --prefix "${copilot_prefix}" "${copilot_pkg}"
 ln -sfn "${copilot_prefix}/bin/copilot" "${bin_dir}/copilot-real"
 ln -sfn "${skills_root}" "${config_home}/skills"
 
 install -m 0755 "${repo_root}/runtime/copilotpod/bin/copilot" "${bin_dir}/copilot"
 install -m 0755 "${repo_root}/runtime/copilotpod/bin/copilotpod-shell" "${bin_dir}/copilotpod-shell"
+install -m 0755 "${repo_root}/runtime/copilotpod/bin/copilotpod-upgrade" "${bin_dir}/copilotpod-upgrade"

--- a/runtime/geminipod/bin/geminipod-upgrade
+++ b/runtime/geminipod/bin/geminipod-upgrade
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+prefix="${OHMYDEVPOD_PREFIX:-${HOME}/.local/geminipod}"
+bin_dir="${OHMYDEVPOD_BIN_DIR:-/usr/local/bin}"
+cli_prefix="${prefix}/opt/gemini-cli"
+
+old_version="$(gemini-real --version 2>/dev/null || echo 'unknown')"
+
+pkg="@google/gemini-cli"
+[[ -n "${version}" ]] && pkg="${pkg}@${version}"
+
+npm install -g --prefix "${cli_prefix}" "${pkg}"
+ln -sfn "${cli_prefix}/bin/gemini" "${bin_dir}/gemini-real"
+
+new_version="$(gemini-real --version 2>/dev/null || echo 'unknown')"
+echo "Upgraded gemini: ${old_version} -> ${new_version}"

--- a/runtime/geminipod/install-harness.sh
+++ b/runtime/geminipod/install-harness.sh
@@ -6,7 +6,7 @@ prefix="${OHMYDEVPOD_PREFIX:?missing OHMYDEVPOD_PREFIX}"
 bin_dir="${OHMYDEVPOD_BIN_DIR:?missing OHMYDEVPOD_BIN_DIR}"
 config_home="${OHMYDEVPOD_CONFIG_HOME:?missing OHMYDEVPOD_CONFIG_HOME}"
 gemini_prefix="${prefix}/opt/gemini-cli"
-gemini_version="${OHMYDEVPOD_GEMINI_VERSION:-0.37.1}"
+gemini_version="${OHMYDEVPOD_GEMINI_VERSION:-}"
 skills_root="${repo_root}/runtime/geminipod/skills"
 
 if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
@@ -24,9 +24,12 @@ mkdir -p "${gemini_prefix}" "${config_home}"
 if [[ ! -f "${config_home}/projects.json" ]]; then
   printf "{}\n" > "${config_home}/projects.json"
 fi
-npm install -g --prefix "${gemini_prefix}" "@google/gemini-cli@${gemini_version}"
+gemini_pkg="@google/gemini-cli"
+[[ -n "${gemini_version}" ]] && gemini_pkg="${gemini_pkg}@${gemini_version}"
+npm install -g --prefix "${gemini_prefix}" "${gemini_pkg}"
 ln -sfn "${gemini_prefix}/bin/gemini" "${bin_dir}/gemini-real"
 ln -sfn "${skills_root}" "${config_home}/skills"
 
 install -m 0755 "${repo_root}/runtime/geminipod/bin/gemini" "${bin_dir}/gemini"
 install -m 0755 "${repo_root}/runtime/geminipod/bin/geminipod-shell" "${bin_dir}/geminipod-shell"
+install -m 0755 "${repo_root}/runtime/geminipod/bin/geminipod-upgrade" "${bin_dir}/geminipod-upgrade"

--- a/runtime/openpod/bin/openpod-upgrade
+++ b/runtime/openpod/bin/openpod-upgrade
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+prefix="${OHMYDEVPOD_PREFIX:-${HOME}/.local/openpod}"
+bin_dir="${OHMYDEVPOD_BIN_DIR:-/usr/local/bin}"
+cli_prefix="${prefix}/opt/opencode-cli"
+
+old_version="$(opencode --version 2>/dev/null || echo 'unknown')"
+
+pkg="opencode-ai"
+[[ -n "${version}" ]] && pkg="${pkg}@${version}"
+
+npm install -g --prefix "${cli_prefix}" "${pkg}"
+ln -sfn "${cli_prefix}/bin/opencode" "${bin_dir}/opencode"
+
+new_version="$(opencode --version 2>/dev/null || echo 'unknown')"
+echo "Upgraded opencode: ${old_version} -> ${new_version}"

--- a/runtime/openpod/install-harness.sh
+++ b/runtime/openpod/install-harness.sh
@@ -7,6 +7,7 @@ config_home="${OHMYDEVPOD_CONFIG_HOME:?missing OHMYDEVPOD_CONFIG_HOME}"
 runtime_vendor_home="${OHMYDEVPOD_RUNTIME_VENDOR_HOME:?missing OHMYDEVPOD_RUNTIME_VENDOR_HOME}"
 prefix="${OHMYDEVPOD_PREFIX:?missing OHMYDEVPOD_PREFIX}"
 shell_dir="${OHMYDEVPOD_SHELL_DIR:?missing OHMYDEVPOD_SHELL_DIR}"
+opencode_version="${OHMYDEVPOD_OPENCODE_VERSION:-}"
 openpod_vendor_home="${runtime_vendor_home}/opencode"
 
 if [[ ! -d "${openpod_vendor_home}" ]]; then
@@ -33,8 +34,11 @@ if [[ "${need_opencode_install}" == "1" ]]; then
   fi
   opencode_prefix="${prefix}/opt/opencode-cli"
   mkdir -p "${opencode_prefix}"
-  npm install -g --prefix "${opencode_prefix}" opencode-ai@1.3.13
+  opencode_pkg="opencode-ai"
+  [[ -n "${opencode_version}" ]] && opencode_pkg="${opencode_pkg}@${opencode_version}"
+  npm install -g --prefix "${opencode_prefix}" "${opencode_pkg}"
   ln -sfn "${opencode_prefix}/bin/opencode" "${bin_dir}/opencode"
 fi
 
 install -m 0755 "${repo_root}/runtime/openpod/bin/openpod-shell" "${bin_dir}/openpod-shell"
+install -m 0755 "${repo_root}/runtime/openpod/bin/openpod-upgrade" "${bin_dir}/openpod-upgrade"


### PR DESCRIPTION
## Summary
- Bootstrap (`install/bootstrap.sh`) now installs the latest harness version by default — no more hardcoded versions in `install-harness.sh`. Docker images still pin specific versions via `ENV`.
- Each flavor gets a `<flavor>-upgrade [VERSION]` command for in-container upgrades:
  - `openpod-upgrade`, `claudepod-upgrade`, `codexpod-upgrade`, `copilotpod-upgrade`, `geminipod-upgrade`
  - Omit VERSION to upgrade to latest; provide VERSION to pin a specific release
- `build/install-claude-code.sh` now resolves "latest" from the npm registry when no version is specified

Closes #78

## Test plan
- [ ] `docker compose -f docker/claudepod/docker-compose.yaml build devpod claudepod` succeeds
- [ ] `claudepod-upgrade` inside container resolves and installs latest Claude Code
- [ ] `codexpod-upgrade 0.118.0` installs the pinned version
- [ ] `bootstrap.sh --flavor codexpod --user` installs latest codex (no pinned version)
- [ ] Docker builds still use pinned versions from Dockerfile ENV lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)