### PR TITLE
fix(install): ensure XDG user dirs exist before writing

### DIFF
--- a/install/setup.sh
+++ b/install/setup.sh
@@ -25,6 +25,14 @@ for cmd in bash curl git; do
   command -v "$cmd" >/dev/null 2>&1 || error "Missing required command: $cmd"
 done
 
+# ── Ensure user dirs exist (fresh systems may lack these) ────────────
+mkdir -p \
+  "${HOME}/.config" \
+  "${HOME}/.cache" \
+  "${HOME}/.local/bin" \
+  "${HOME}/.local/share" \
+  "${DEVPOD_ZSH}"
+
 # ── Mirror infrastructure ────────────────────────────────────────────
 info "Probing git hosts..."
 MIRROR_HOSTS=()
@@ -184,7 +192,6 @@ uv tool install --force "harlequin==2.5.2" || warn "Harlequin installation faile
 
 # ── Vendored assets (zsh plugins + p10k) ─────────────────────────────
 info "Downloading vendored assets from mirrors..."
-mkdir -p "${DEVPOD_ZSH}"
 
 _asset_tmp="$(mktemp -d)"
 zsh_plugin_ok=true


### PR DESCRIPTION
## Summary
- Fresh systems (e.g. brand-new WSL accounts) may not have `~/.config`, which caused `cp -R … ~/.config/nvim` to fail with `No such file or directory` during LazyVim setup, aborting the one-line installer.
- Create `~/.config`, `~/.cache`, `~/.local/bin`, `~/.local/share`, and `${DEVPOD_ZSH}` once near the top of `install/setup.sh` so all later writes are safe; removed the now-redundant mid-script `mkdir`.

## Test plan
- [x] `bash -n install/setup.sh`
- [ ] Run installer on a fresh WSL/Ubuntu account where `~/.config` does not pre-exist; LazyVim step completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)