### PR TITLE
fix(install): use correct tarball subdirectory path for atuin binary

### DIFF
--- a/build/install-atuin.sh
+++ b/build/install-atuin.sh
@@ -47,6 +47,6 @@ fi
 tar -xzf "${archive_path}" -C "${tmp_dir}"
 
 mkdir -p "${bin_dir}"
-install -m 0755 "${tmp_dir}/atuin" "${bin_dir}/atuin"
+install -m 0755 "${tmp_dir}/atuin-${atuin_arch}-unknown-linux-musl/atuin" "${bin_dir}/atuin"
 
 test -x "${bin_dir}/atuin"


### PR DESCRIPTION
## Summary
- Fix atuin install script that fails because the release tarball extracts into a subdirectory `atuin-{arch}-unknown-linux-musl/` rather than flat files
- This was the root cause of all release build failures since atuin was added

## Test plan
- [ ] Verify locally: `tar -tzf vendor/releases/atuin/v18.15.2/atuin-x86_64-unknown-linux-musl.tar.gz` shows the subdirectory structure
- [ ] Run a release build to confirm the workflow passes

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)