### PR TITLE
chore: replace stale oh-my-openpod references in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         Thanks for reporting a bug.
 
-        Please include enough detail for us to reproduce the issue inside `oh-my-openpod`.
+        Please include enough detail for us to reproduce the issue inside `oh-my-devpod`.
   - type: textarea
     id: summary
     attributes:
@@ -21,7 +21,7 @@ body:
     attributes:
       label: Version / 版本
       description: Image tag, commit SHA, or branch name.
-      placeholder: "Example: ghcr.io/zhangdw156/oh-my-openpod:latest"
+      placeholder: "Example: ghcr.io/zhangdw156/oh-my-devpod:latest"
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation / 文档
-    url: https://github.com/zhangdw156/oh-my-openpod/blob/main/README.md
+    url: https://github.com/zhangdw156/oh-my-devpod/blob/main/README.md
     about: Check the README before opening an issue.


### PR DESCRIPTION
## Summary
- Replace all `oh-my-openpod` references with `oh-my-devpod` in `.github/ISSUE_TEMPLATE/config.yml` and `bug_report.yml`
- The repo was renamed but these templates still pointed to the old name, causing confusion in issue forms and contributing to stale email thread subjects

## Test plan
- [ ] Verify issue template URLs resolve correctly after merge
- [ ] Open a new issue via the web UI to confirm the updated placeholder text

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)